### PR TITLE
Fixes an issue where the 'No Facilitators Currently Available' messag…

### DIFF
--- a/src/EventSubscriber/QuizResultPageSubscriber.php
+++ b/src/EventSubscriber/QuizResultPageSubscriber.php
@@ -114,7 +114,9 @@ final class QuizResultPageSubscriber implements EventSubscriberInterface {
         $config = $this->configFactory->get('assign_badge_from_quiz.settings');
         $show_details_for_types = $config->get('show_badge_details') ?: [];
         if ($badge_term && in_array($quiz_type, $show_details_for_types, TRUE)) {
-            $controller_result['assign_badge_facilitator_schedule'] = $this->displayBuilder->buildFacilitatorSchedule($badge_term);
+            if (isset($context['badge']['checkout_requirement']) && $context['badge']['checkout_requirement'] !== 'no') {
+                $controller_result['assign_badge_facilitator_schedule'] = $this->displayBuilder->buildFacilitatorSchedule($badge_term);
+            }
         }
     }
     else {


### PR DESCRIPTION
…e was displayed for badges that do not require a checkout.

The logic that displays the facilitator schedule was not checking if a checkout was required for the badge. This change adds a condition to ensure the facilitator schedule is only displayed when a checkout is required.